### PR TITLE
Added tox.ini to examples and updated README with instructions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,9 @@ These examples are scripts that can be run independently to demonstrate the Rose
 
 Prerequisite: Either run `pip install rosette_api` or run `python setup.py install` in the python top level folder.
 
+Alternatively, you can run all the examples with the command line:
+`find -maxdepth 1 -name "*.py" -exec tox -- {} --key api-key --url alternate_url \;`
+
 You can now run your desired _endpoint_.py file to see it in action.
 For example, run `python/examples/categories.py` if you want to see the categories
 functionality demonstrated.

--- a/examples/tox.ini
+++ b/examples/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+skipsdist = True
+envlist = py27
+
+[testenv]
+commands =
+    {envpython} {posargs}
+deps =
+    rosette-api


### PR DESCRIPTION
This provides a command line solution to running all of the examples against a target url