### PR TITLE
Updated make_request to use Requests

### DIFF
--- a/rosette/api.py
+++ b/rosette/api.py
@@ -546,8 +546,6 @@ class API:
         else:
             self.session.mount('http://', adapter)
 
-
-
     def _make_request(self, op, url, data, headers):
         """
         Handles the actual request, retrying if a 429 is encountered
@@ -579,7 +577,6 @@ class API:
                     if dict_headers['x-rosetteapi-concurrency'] != self.maxPoolSize:
                         self.maxPoolSize = dict_headers['x-rosetteapi-concurrency']
                         self._set_pool_size()
-
 
                 if status == 200:
                     return rdata, status, response_headers

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -170,6 +170,24 @@ def test_for_409(api, json_409):
     httpretty.disable()
     httpretty.reset()
 
+# Test the maxPoolSize
+
+
+def test_the_max_pool_size(json_response, doc_params):
+    httpretty.enable()
+    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/language",
+                           body=json_response, status=200, content_type="application/json",
+                           adding_headers={
+                               'x-rosetteapi-concurrency': 5
+                           })
+    api = API('bogus_key')
+    assert api.getPoolSize() == 1
+    result = api.language(doc_params)
+    assert result["name"] == "Rosette API"
+    assert api.getPoolSize() == 5
+    httpretty.disable()
+    httpretty.reset()
+
 # Test the language endpoint
 
 


### PR DESCRIPTION
Multipart was already using Requests.  make_request was still using http_connection, which was failing when running the Python examples through the Docker container against the NGINX on Seuss.  Changing to Requests helps with consistency in the binding and resolves the 404 that was being thrown.