### PR TITLE
RCB-547 Remove hardcoded version from test

### DIFF
--- a/rosette/api.py
+++ b/rosette/api.py
@@ -575,6 +575,10 @@ class API(object):
         except ReferenceError:
             pass
 
+    def get_binding_version(self):
+        """ Return the current binding version """
+        return _BINDING_VERSION
+
     def get_user_agent_string(self):
         """ Return the User-Agent string """
         return self.user_agent_string

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -31,7 +31,6 @@ from rosette.api import(API,
                         RosetteException)
 
 _ISPY3 = sys.version_info[0] == 3
-_BINDING_VERSION = '1.8.2'
 
 
 @pytest.fixture
@@ -138,7 +137,7 @@ def test_invalid_header(api):
 
 def test_user_agent(api):
     """ Test user agent """
-    value = "RosetteAPIPython/" + _BINDING_VERSION + "/" + platform.python_version()
+    value = "RosetteAPIPython/" + api.get_binding_version() + "/" + platform.python_version()
     assert value == api.get_user_agent_string()
 
 # Test that pinging the API is working properly


### PR DESCRIPTION
- Added a method off of api to return currrent binding version
- Replaced the hardcoded version in the test with the api call