### PR TITLE
DEVOPS-306:  Add 3.12.  Remove 3.7.

### DIFF
--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -1,6 +1,6 @@
 
 
-def versions = [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+def versions = [3.8, 3.9, 3.10, 3.11, 3.12]
 
 def runSonnarForPythonVersion(sourceDir, ver){
     mySonarOpts="-Dsonar.sources=/source -Dsonar.host.url=${env.SONAR_HOST_URL} -Dsonar.login=${env.SONAR_AUTH_TOKEN}"
@@ -15,7 +15,7 @@ def runSonnarForPythonVersion(sourceDir, ver){
 
     // Only run Sonar once.
     // Check for new versions at https://binaries.sonarsource.com/?prefix=Distribution/sonar-scanner-cli/
-    if(ver == 3.13) {
+    if(ver == 3.12) {
         sonarExec="cd /root/ && \
                    wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.8.1.3023-linux.zip && \
                    unzip -q sonar-scanner-cli-4.8.1.3023-linux.zip && \

--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -1,6 +1,6 @@
 
 
-def versions = [3.7, 3.8, 3.9, 3.10, 3.11]
+def versions = [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
 
 def runSonnarForPythonVersion(sourceDir, ver){
     mySonarOpts="-Dsonar.sources=/source -Dsonar.host.url=${env.SONAR_HOST_URL} -Dsonar.login=${env.SONAR_AUTH_TOKEN}"
@@ -15,7 +15,7 @@ def runSonnarForPythonVersion(sourceDir, ver){
 
     // Only run Sonar once.
     // Check for new versions at https://binaries.sonarsource.com/?prefix=Distribution/sonar-scanner-cli/
-    if(ver == 3.11) {
+    if(ver == 3.13) {
         sonarExec="cd /root/ && \
                    wget -q https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.8.1.3023-linux.zip && \
                    unzip -q sonar-scanner-cli-4.8.1.3023-linux.zip && \

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,12 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )


### PR DESCRIPTION
Originally, I misread [the chart](https://devguide.python.org/versions/) and didn't see that 3.13 is still in pre-release.