### PR TITLE
WS-3224: fix requests compatibility issue

### DIFF
--- a/examples/record_similarity.py
+++ b/examples/record_similarity.py
@@ -50,7 +50,8 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
                 "dob": "1993-04-16",
                 "addr": "123 Roadlane Ave",
                 "dob2": {
-                    "date": "1993/04/16"
+                    "date": "04161993",
+                    "format": "MMddyyyy"
                 }
             },
             {
@@ -78,7 +79,8 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
                     "date": "1993-04-16"
                 },
                 "addr": {
-                  "address": "123 Roadlane Ave"
+                  "houseNumber": "123",
+                  "road": "Roadlane Ave"
                 },
                 "dob2": {
                     "date": "1993/04/16"

--- a/rosette/api.py
+++ b/rosette/api.py
@@ -360,7 +360,7 @@ class RecordSimilarityParameters(_RequestParametersBase):
 
     def validate(self):
         """Internal. Do not use."""
-        for option in "records":  # required
+        for option in ["records"]:  # required
             if self[option] is None:
                 raise RosetteException(
                     "missingParameter",

--- a/rosette/api.py
+++ b/rosette/api.py
@@ -528,7 +528,7 @@ class EndpointCaller(object):
             request = requests.Request(
                 'POST', url, files=files, headers=headers, params=payload)
             prepared_request = self.api.session.prepare_request(request)
-            settings = self.api.session.merge_environment_settings(prepared_request.url, {}, {}, None, {})
+            settings = self.api.session.merge_environment_settings(prepared_request.url, {}, {}, None, None)
             response = self.api.session.send(prepared_request, **settings)
             rdata = response.content
             response_headers = {"responseHeaders": dict(response.headers)}
@@ -671,7 +671,7 @@ class API(object):
             operation, url, data=data, headers=headers, params=payload)
         prepared_request = self.session.prepare_request(request)
         # Take into account environment settings, e.g. HTTP_PROXY and HTTPS_PROXY
-        settings = self.session.merge_environment_settings(prepared_request.url, {}, {}, None, {})
+        settings = self.session.merge_environment_settings(prepared_request.url, {}, {}, None, None)
 
         try:
             response = self.session.send(prepared_request, **settings)

--- a/rosette/api.py
+++ b/rosette/api.py
@@ -360,7 +360,7 @@ class RecordSimilarityParameters(_RequestParametersBase):
 
     def validate(self):
         """Internal. Do not use."""
-        for option in "fields", "properties", "records":  # required
+        for option in "records":  # required
             if self[option] is None:
                 raise RosetteException(
                     "missingParameter",

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -997,22 +997,6 @@ def test_for_record_similarity_required_parameters(api, json_response):
         api.record_similarity(params)
 
     assert e_rosette.value.status == 'missingParameter'
-    assert e_rosette.value.message == 'Required Record Similarity parameter is missing: fields'
-
-    params["fields"] = {}
-
-    with pytest.raises(RosetteException) as e_rosette:
-        api.record_similarity(params)
-
-    assert e_rosette.value.status == 'missingParameter'
-    assert e_rosette.value.message == 'Required Record Similarity parameter is missing: properties'
-
-    params["properties"] = {}
-
-    with pytest.raises(RosetteException) as e_rosette:
-        api.record_similarity(params)
-
-    assert e_rosette.value.status == 'missingParameter'
     assert e_rosette.value.message == 'Required Record Similarity parameter is missing: records'
 
     params["records"] = {}


### PR DESCRIPTION
- requests >=2.32.0 replaces the internal `_get_connection` method with, `_get_connection_with_tls_context`. This propagates the cert param down to the connection pool which fails (I believe it expects a string). This was not the case with the previous versions as those did not use the default SSLContext on every request
- 1.30.0 record-similarity changes