### PR TITLE
Ws 3314 update key header and urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
-<a href="https://www.babelstreet.com/rosette"><img src="https://charts.babelstreet.com/icon.png" width="47" height="60"/></a>
-# Rosette by Babel Street
+<a href="https://www.babelstreet.com/rosette">
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-dark.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-light.png">
+  <img alt="Babel Street Logo" width="48" height="48">
+</picture>
+</a>
+
+# Analytics by Babel Street
 
 [![PyPI version](https://badge.fury.io/py/rosette-api.svg)](https://badge.fury.io/py/rosette-api)
 [![Python Versions](https://img.shields.io/pypi/pyversions/rosette-api.svg?color=dark%20green&label=Python%20Versions)](https://img.shields.io/pypi/pyversions/rosette-api.svg?color=dark%20green&label=Python%20Versions)
 
-Rosette uses natural language processing, statistical modeling, and machine learning to analyze unstructured and semi-structured text across hundreds of language-script combinations, revealing valuable information and actionable data. Rosette provides endpoints for extracting entities and relationships, translating and comparing the similarity of names, categorizing and adding linguistic tags to text and more. Rosette Server is the on-premises installation of Rosette, with access to Rosette's functions as RESTful web service endpoints. This solves cloud security worries and allows customization (models/indexes) as needed for your business.
+Our product is a full text processing pipeline from data preparation to extracting the most relevant information and 
+analysis utilizing precise, focused AI that has built-in human understanding. Text Analytics provides foundational 
+linguistic analysis for identifying languages and relating words. The result is enriched and normalized text for 
+high-speed search and processing without translation.
 
-## Rosette API Access
-- Rosette Cloud [Sign Up](https://developer.rosette.com/signup)
+Text Analytics extracts events and entities — people, organizations, and places — from unstructured text and adds the 
+structure of associating those entities into events that deliver only the necessary information for near real-time 
+decision making. Accompanying tools shorten the process of training AI models to recognize domain-specific events.
+
+The product delivers a multitude of ways to sharpen and expand search results. Semantic similarity expands search 
+beyond keywords to words with the same meaning, even in other languages. Sentiment analysis and topic extraction help 
+filter results to what’s relevant.
+
+## Analytics API Access
+- Analytics Cloud [Sign Up](https://developer.babelstreet.com/signup)
 
 ## Quick Start
 
@@ -15,14 +33,14 @@ Rosette uses natural language processing, statistical modeling, and machine lear
 `pip install rosette_api`
 
 #### Examples
-View small example programs for each Rosette endpoint
+View small example programs for each Analytics endpoint
 in the [examples](https://github.com/rosette-api/python/tree/develop/examples) directory.
 
 #### Documentation & Support
 - [Binding API](https://rosette-api.github.io/python/)
-- [Rosette Platform API](https://docs.babelstreet.com/API/en/index-en.html)
+- [Analytics Platform API](https://docs.babelstreet.com/API/en/index-en.html)
 - [Binding Release Notes](https://github.com/rosette-api/python/wiki/Release-Notes)
-- [Rosette Platform Release Notes](https://babelstreet.my.site.com/support/s/article/Rosette-Cloud-Release-Notes)
+- [Analytics Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
 - [Support](https://babelstreet.my.site.com/support/s/)
 - [Binding License: Apache 2.0](https://github.com/rosette-api/python/blob/develop/LICENSE.txt)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,8 +47,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = ''
-copyright = '2024, Basis Technology'
-author = 'Basis Technology'
+copyright = '2024, Babel Street'
+author = 'Babel Street'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 
 Python Binding
 ==========================================
-This is the API documentation for the Babel Street Analytics API Python Binding.  For examples and usage, please refer to our `API Guide <http://developer.rosette.com/api-guide>`_.
+This is the API documentation for the Babel Street Analytics API Python Binding.  For examples and usage, please refer to our `API Guide <http://developer.babelstreet.com/api-guide>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 
 Python Binding
 ==========================================
-This is the API documentation for the Rosette API Python Binding.  For examples and usage, please refer to our `API Guide <http://developer.rosette.com/api-guide>`_.
+This is the API documentation for the Babel Street Analytics API Python Binding.  For examples and usage, please refer to our `API Guide <http://developer.rosette.com/api-guide>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ A note on prerequisites.  Analytics API only supports TLS 1.2 so ensure your too
 ```
 git clone git@github.com:rosette-api/python.git
 cd python/examples
-virtualenv analytics_venv
+python -m venv analytics_venv
 source analytics_venv/bin/activate
 pip install rosette_api
 python ping.py -k $API_KEY
@@ -21,7 +21,7 @@ python ping.py -k $API_KEY
 ```
 git clone git@github.com:rosette-api/python.git
 cd python
-virtualenv analytics_venv
+python -m venv analytics_venv
 source analytics_venv/bin/activate
 python setup.py install
 cd examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,18 @@
 ## Endpoint Examples
 
-Each example file demonstrates one of the capabilities of the Rosette Platform.
+Each example file demonstrates one of the capabilities of the Babel Street Analytics Platform.
 
 Here are some methods for running the examples.  Each example will also accept an optional `--url` parameter for
 overriding the default URL.
 
-A note on prerequisites.  Rosette API only supports TLS 1.2 so ensure your toolchain also supports it.
+A note on prerequisites.  Analytics API only supports TLS 1.2 so ensure your toolchain also supports it.
 
 #### Virtualenv/Latest Release
 ```
 git clone git@github.com:rosette-api/python.git
 cd python/examples
-virtualenv rosette_venv
-source rosette_venv/bin/activate
+virtualenv analytics_venv
+source analytics_venv/bin/activate
 pip install rosette_api
 python ping.py -k $API_KEY
 ```
@@ -21,8 +21,8 @@ python ping.py -k $API_KEY
 ```
 git clone git@github.com:rosette-api/python.git
 cd python
-virtualenv rosette_venv
-source rosette_venv/bin/activate
+virtualenv analytics_venv
+source analytics_venv/bin/activate
 python setup.py install
 cd examples
 python ping.py -k $API_KEY

--- a/examples/address_similarity.py
+++ b/examples/address_similarity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get match score (similarity) of two addresses.
+Example code to call Analytics API to get match score (similarity) of two addresses.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, AddressSimilarityParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -29,9 +29,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/categories.py
+++ b/examples/categories.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Example code to call Rosette API to get the category of a document (at a given URL).
+Example code to call Analytics API to get the category of a document (at a given URL).
 """
 
 import argparse
@@ -12,7 +12,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     categories_text_data = "If you are a fan of the British television series Downton Abbey and you are planning to be in New York anytime before April 2nd, there is a perfect stop for you while in town."
     # Create an API instance
@@ -20,8 +20,8 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 
     # Set selected API options
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#categorization
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#categorization
 
     # api.set_option('singleLabel', 'true')
     # api.set_option('scoreThreshold',- 0.20)
@@ -38,9 +38,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/entities.py
+++ b/examples/entities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get entities from a piece of text.
+Example code to call Analytics API to get entities from a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#entity-extraction-and-linking
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#entity-extraction-and-linking
 
     # api.set_option('calculateSalience','true')
     # api.set_option('linkEntities','false')
@@ -36,9 +36,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get events from a piece of text.
+Example code to call Analytics API to get events from a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -27,9 +27,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/events_negation.py
+++ b/examples/events_negation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get events, based on a set negation option, from a piece of text.
+Example code to call Analytics API to get events, based on a set negation option, from a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -31,9 +31,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/info.py
+++ b/examples/info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get information such as version and build
+Example code to call Analytics API to get information such as version and build
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -24,9 +24,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/language.py
+++ b/examples/language.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to determine the language of a piece of text.
+Example code to call Analytics API to determine the language of a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -28,9 +28,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/language_multilingual.py
+++ b/examples/language_multilingual.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to determine the language of a piece of text.
+Example code to call Analytics API to determine the language of a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -30,9 +30,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/morphology_complete.py
+++ b/examples/morphology_complete.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get the complete morphological analysis of a piece of text.
+Example code to call Analytics API to get the complete morphological analysis of a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#morphological-analysis-introduction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#morphological-analysis-introduction
 
     # api.set_option('modelType','perceptron') #Valid for Chinese and Japanese only
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/morphology_compound-components.py
+++ b/examples/morphology_compound-components.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get de-compounded words from a piece of text.
+Example code to call Analytics API to get de-compounded words from a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#morphological-analysis-introduction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#morphological-analysis-introduction
 
     # api.set_option('modelType','perceptron') #Valid for Chinese and Japanese only
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/morphology_han-readings.py
+++ b/examples/morphology_han-readings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get Chinese readings of words in a piece of text.
+Example code to call Analytics API to get Chinese readings of words in a piece of text.
 """
 
 import argparse
@@ -10,14 +10,14 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#morphological-analysis-introduction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#morphological-analysis-introduction
 
     # api.set_option('modelType','perceptron') #Valid for Chinese and Japanese only
 
@@ -33,9 +33,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/morphology_lemmas.py
+++ b/examples/morphology_lemmas.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get lemmas for words in a piece of text.
+Example code to call Analytics API to get lemmas for words in a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#morphological-analysis-introduction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#morphological-analysis-introduction
 
     # api.set_option('modelType','perceptron') #Valid for Chinese and Japanese only
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/morphology_parts-of-speech.py
+++ b/examples/morphology_parts-of-speech.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get part-of-speech tags for words in a piece of text.
+Example code to call Analytics API to get part-of-speech tags for words in a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#morphological-analysis-introduction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#morphological-analysis-introduction
 
     # api.set_option('modelType','perceptron') # Valid for Chinese and Japanese only
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/name_deduplication.py
+++ b/examples/name_deduplication.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to deduplicate a list of names.
+Example code to call Analytics API to deduplicate a list of names.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, NameDeduplicationParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -29,9 +29,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/name_similarity.py
+++ b/examples/name_similarity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get match score (similarity) of two names.
+Example code to call Analytics API to get match score (similarity) of two names.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, NameSimilarityParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -31,9 +31,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/name_translation.py
+++ b/examples/name_translation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to translate a name from one language to another.
+Example code to call Analytics API to translate a name from one language to another.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, NameTranslationParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -30,9 +30,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to send Rosette API a ping to check its reachability.
+Example code to send Analytics API a ping to check its reachability.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -24,9 +24,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/record_similarity.py
+++ b/examples/record_similarity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get similarity score between a list of records
+Example code to call Analytics API to get similarity score between a list of records
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, RecordSimilarityParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -102,9 +102,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/relationships.py
+++ b/examples/relationships.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get entities's relationships from a piece of text.
+Example code to call Analytics API to get entities's relationships from a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -26,9 +26,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 API_KEY [ALT_URL]" 1>&2
+    exit 1
+fi
 OPTS=""
 if [ -n "$2" ]; then
     OPTS="-u $2"

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -4,12 +4,12 @@ if [ $# -eq 0 ]; then
     echo "Usage: $0 API_KEY [ALT_URL]" 1>&2
     exit 1
 fi
-OPTS=""
-if [ -n "$2" ]; then
-    OPTS="-u $2"
-fi
 
 for f in *.py
 do
-    python $f --key $1 "$OPTS"
+  if [ -n "$2" ]; then
+    python $f --key $1 --url $2
+  else
+    python $f --key $1
+  fi
 done

--- a/examples/run_all.sh
+++ b/examples/run_all.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+
+OPTS=""
+if [ -n "$2" ]; then
+    OPTS="-u $2"
+fi
+
 for f in *.py
 do
-    python $f --key $1
+    python $f --key $1 "$OPTS"
 done

--- a/examples/semantic_vectors.py
+++ b/examples/semantic_vectors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get text vectors from a piece of text.
+Example code to call Analytics API to get text vectors from a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#semantic-vectors
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#semantic-vectors
 
     # api.set_option('perToken', 'true')
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/sentences.py
+++ b/examples/sentences.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get sentences in a piece of text.
+Example code to call Analytics API to get sentences in a piece of text.
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
@@ -28,9 +28,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/sentiment.py
+++ b/examples/sentiment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get the sentiment of a local file.
+Example code to call Analytics API to get the sentiment of a local file.
 """
 
 import argparse
@@ -12,7 +12,7 @@ import tempfile
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create default file to read from
     temp_file = tempfile.NamedTemporaryFile(suffix=".html")
@@ -25,8 +25,8 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
     api = API(user_key=key, service_url=alt_url)
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#sentiment-analysis
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#sentiment-analysis
 
     # api.set_option('modelType','dnn') #Valid for English only
 
@@ -49,9 +49,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/similar_terms.py
+++ b/examples/similar_terms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get similar terms for an input.
+Example code to call Analytics API to get similar terms for an input.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#similar-terms
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#similar-terms
 
     api.set_option("resultLanguages", ['spa', 'deu', 'jpn'])
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                              os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/syntax_dependencies.py
+++ b/examples/syntax_dependencies.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get the syntactic dependencies of a document (at a given URL).
+Example code to call Analytics API to get the syntactic dependencies of a document (at a given URL).
 """
 
 import argparse
@@ -10,7 +10,7 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     syntax_dependencies_data = "Yoshinori Ohsumi, a Japanese cell biologist, was awarded the Nobel Prize in Physiology or Medicine on Monday."
     params = DocumentParameters()
@@ -26,9 +26,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/tokens.py
+++ b/examples/tokens.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get the tokens (words) in a piece of text.
+Example code to call Analytics API to get the tokens (words) in a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#tokenization
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#tokenization
 
     # api.set_option('modelType','perceptron') #Valid for Chinese and Japanese only
 
@@ -34,9 +34,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/topics.py
+++ b/examples/topics.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to get the topics (key phrases and concepts) in a piece of text.
+Example code to call Analytics API to get the topics (key phrases and concepts) in a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#topic-extraction
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#topic-extraction
 
     # api.set_option('keyphraseSalienceThreshold','.5')
     # api.set_option('conceptSalienceThreshold','.1')
@@ -35,9 +35,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/examples/transliteration.py
+++ b/examples/transliteration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Example code to call Rosette API to transliterate a piece of text.
+Example code to call Analytics API to transliterate a piece of text.
 """
 
 import argparse
@@ -10,15 +10,15 @@ import os
 from rosette.api import API, DocumentParameters, RosetteException
 
 
-def run(key, alt_url='https://api.rosette.com/rest/v1/'):
+def run(key, alt_url='https://analytics.babelstreet.com/rest/v1/'):
     """ Run the example """
     # Create an API instance
     api = API(user_key=key, service_url=alt_url)
 
     # Set selected API options.
     # For more information on the functionality of these
-    # and other available options, see Rosette Features & Functions
-    # https://developer.rosette.com/features-and-functions#transliteration
+    # and other available options, see Analytics Features & Functions
+    # https://developer.babelstreet.com/features-and-functions#transliteration
 
     # To transliterate from native Arabic script to Arabizi add:
     # api.set_option('reversed','True')
@@ -36,9 +36,9 @@ def run(key, alt_url='https://api.rosette.com/rest/v1/'):
 PARSER = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                  description='Calls the ' +
                                  os.path.splitext(os.path.basename(__file__))[0] + ' endpoint')
-PARSER.add_argument('-k', '--key', help='Rosette API Key', required=True)
+PARSER.add_argument('-k', '--key', help='Analytics API Key', required=True)
 PARSER.add_argument('-u', '--url', help="Alternative API URL",
-                    default='https://api.rosette.com/rest/v1/')
+                    default='https://analytics.babelstreet.com/rest/v1/')
 
 if __name__ == '__main__':
     ARGS = PARSER.parse_args()

--- a/rosette/__init__.py
+++ b/rosette/__init__.py
@@ -1,5 +1,5 @@
 """
-Python client for the Rosette API.
+Python client for the Babel Street Analytics API.
 Copyright (c) 2014-2022 Basis Technology Corporation.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/rosette/__init__.py
+++ b/rosette/__init__.py
@@ -1,6 +1,6 @@
 """
 Python client for the Babel Street Analytics API.
-Copyright (c) 2014-2022 Basis Technology Corporation.
+Copyright (c) 2014-2024 Basis Technology Corporation.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/rosette/api.py
+++ b/rosette/api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Python client for the Rosette API.
+Python client for the Babel Street Analytics API.
 
 Copyright (c) 2014-2024 Basis Technology Corporation.
 
@@ -68,7 +68,7 @@ def _my_loads(obj, response_headers):
 
 
 class RosetteException(Exception):
-    """Exception thrown by all Rosette API operations for errors local and remote.
+    """Exception thrown by all Analytics API operations for errors local and remote.
 
     TBD. Right now, the only valid operation is conversion to __str__.
     """
@@ -96,13 +96,13 @@ class _RequestParametersBase(object):
     def __setitem__(self, key, val):
         if key not in self.__params:
             raise RosetteException(
-                "badKey", "Unknown Rosette parameter key", repr(key))
+                "badKey", "Unknown Analytics parameter key", repr(key))
         self.__params[key] = val
 
     def __getitem__(self, key):
         if key not in self.__params:
             raise RosetteException(
-                "badKey", "Unknown Rosette parameter key", repr(key))
+                "badKey", "Unknown Analytics parameter key", repr(key))
         return self.__params[key]
 
     def validate(self):
@@ -370,9 +370,9 @@ class RecordSimilarityParameters(_RequestParametersBase):
 
 class EndpointCaller(object):
     """L{EndpointCaller} objects are invoked via their instance methods to obtain results
-    from the Rosette server described by the L{API} object from which they
+    from the Analytics server described by the L{API} object from which they
     are created.  Each L{EndpointCaller} object communicates with a specific endpoint
-    of the Rosette server, specified at its creation.  Use the specific
+    of the Analytics server, specified at its creation.  Use the specific
     instance methods of the L{API} object to create L{EndpointCaller} objects bound to
     corresponding endpoints.
 
@@ -382,7 +382,7 @@ class EndpointCaller(object):
 
     The results of all operations are returned as python dictionaries, whose
     keys and values correspond exactly to those of the corresponding
-    JSON return value described in the Rosette web service documentation.
+    JSON return value described in the Analytics web service documentation.
     """
 
     def __init__(self, api, suburl):
@@ -413,7 +413,7 @@ class EndpointCaller(object):
                 complaint_url = ename + " " + self.suburl
 
             raise RosetteException(code, complaint_url +
-                                   " : failed to communicate with Rosette", msg)
+                                   " : failed to communicate with Analytics", msg)
 
     def __set_headers(self):
         headers = {'Accept': _APPLICATION_JSON,
@@ -435,7 +435,7 @@ class EndpointCaller(object):
             headers[_CUSTOM_HEADER_PREFIX + 'Devel'] = 'true'
 
         if self.user_key is not None:
-            headers[_CUSTOM_HEADER_PREFIX + "Key"] = self.user_key
+            headers["X-BabelStreetAPI-Key"] = self.user_key
 
         return headers
 
@@ -473,7 +473,7 @@ class EndpointCaller(object):
 
         In all cases, the result is returned as a python dictionary
         conforming to the JSON object described in the endpoint's entry
-        in the Rosette web service documentation.
+        in the Analytics web service documentation.
 
         @param parameters: An object specifying the data,
         and possible metadata, to be processed by the endpoint.  See the
@@ -548,22 +548,22 @@ class EndpointCaller(object):
 
 class API(object):
     """
-    Rosette Python Client Binding API; representation of a Rosette server.
+    Analytics Python Client Binding API; representation of an Analytics server.
     Call instance methods upon this object to obtain L{EndpointCaller} objects
-    which can communicate with particular Rosette server endpoints.
+    which can communicate with particular Analytics server endpoints.
     """
 
     def __init__(
             self,
             user_key=None,
-            service_url='https://api.rosette.com/rest/v1/',
+            service_url='https://analytics.babelstreet.com/rest/v1/',
             retries=5,
             refresh_duration=0.5,
             debug=False):
         """ Create an L{API} object.
         @param user_key: (Optional; required for servers requiring authentication.)
         An authentication string to be sent as user_key with all requests.  The
-        default Rosette server requires authentication to the server.
+        default Analytics server requires authentication to the server.
         """
         # logging.basicConfig(filename="binding.log", filemode="w", level=logging.DEBUG)
         self.user_key = user_key
@@ -703,7 +703,7 @@ class API(object):
         except requests.exceptions.RequestException as exception:
             raise RosetteException(
                 exception,
-                "Unable to establish connection to the Rosette API server",
+                "Unable to establish connection to the Analytics API server",
                 url)
 
         raise RosetteException(code, message, url)

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup
 import rosette
 
 NAME = "rosette_api"
-DESCRIPTION = "Rosette API Python client SDK"
-AUTHOR = "Rosette by Babel Street"
+DESCRIPTION = "Babel Street Analytics API Python client SDK"
+AUTHOR = "Analytics by Babel Street"
 AUTHOR_EMAIL = "helpdesk@babelstreet.com"
 HOMEPAGE = "https://github.com/rosette-api/python"
 VERSION = rosette.__version__

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -38,7 +38,7 @@ _ISPY3 = sys.version_info[0] == 3
 @pytest.fixture
 def json_response():
     """ fixture to return info body"""
-    body = json.dumps({'name': 'Rosette', 'versionChecked': True})
+    body = json.dumps({'name': 'Babel Street Analytics', 'versionChecked': True})
     return body
 
 
@@ -120,7 +120,7 @@ def test_url_parameter_clear_single(api):
 
 def test_custom_header_props(api):
     """Test custom header get/set/clear"""
-    key = 'X-RosetteAPI-Test'
+    key = 'X-BabelStreetAPI-Test'
     value = 'foo'
     api.set_custom_headers(key, value)
     assert value == api.get_custom_headers()[key]
@@ -145,7 +145,7 @@ def test_invalid_header(api):
 
 def test_user_agent(api):
     """ Test user agent """
-    value = "RosetteAPIPython/" + api.get_binding_version() + "/" + platform.python_version()
+    value = "Babel-Street-Analytics-API-Python/" + api.get_binding_version() + "/" + platform.python_version()
     assert value == api.get_user_agent_string()
 
 # Test that pinging the API is working properly
@@ -159,7 +159,7 @@ def test_ping(api, json_response):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.ping()
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -173,7 +173,7 @@ def test_info(api, json_response):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.info()
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -197,7 +197,7 @@ def test_for_409(api, json_409):
 # Test the max_pool_size
 
 
-def test_the_max_pool_size(json_response, doc_params):
+def test_the_max_pool_size_rosette(json_response, doc_params):
     """Test max pool size"""
     httpretty.enable()
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/language",
@@ -208,8 +208,45 @@ def test_the_max_pool_size(json_response, doc_params):
     api = API('bogus_key')
     assert api.get_pool_size() == 1
     result = api.language(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     assert api.get_pool_size() == 5
+    api.set_pool_size(11)
+    assert api.get_pool_size() == 11
+    httpretty.disable()
+    httpretty.reset()
+
+def test_the_max_pool_size_babelstreet(json_response, doc_params):
+    """Test max pool size"""
+    httpretty.enable()
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/language",
+                           body=json_response, status=200, content_type="application/json",
+                           adding_headers={
+                               'x-babelstreetapi-concurrency': 5
+                           })
+    api = API('bogus_key')
+    assert api.get_pool_size() == 1
+    result = api.language(doc_params)
+    assert result["name"] == "Babel Street Analytics"
+    assert api.get_pool_size() == 5
+    api.set_pool_size(11)
+    assert api.get_pool_size() == 11
+    httpretty.disable()
+    httpretty.reset()
+
+def test_the_max_pool_size_bot(json_response, doc_params):
+    """Test max pool size"""
+    httpretty.enable()
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/language",
+                           body=json_response, status=200, content_type="application/json",
+                           adding_headers={
+                               'x-rosetteapi-concurrency': 5,
+                               'x-babelstreetapi-concurrency': 8
+                           })
+    api = API('bogus_key')
+    assert api.get_pool_size() == 1
+    result = api.language(doc_params)
+    assert result["name"] == "Babel Street Analytics"
+    assert api.get_pool_size() == 8
     api.set_pool_size(11)
     assert api.get_pool_size() == 11
     httpretty.disable()
@@ -225,7 +262,7 @@ def test_the_language_endpoint(api, json_response, doc_params, doc_map):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.language(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
 
     with pytest.raises(RosetteException) as e_rosette:
         result = api.language(doc_map)
@@ -244,7 +281,7 @@ def test_the_sentences_endpoint(api, json_response, doc_params, doc_map):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.sentences(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
 
     with pytest.raises(RosetteException) as e_rosette:
         result = api.sentences(doc_map)
@@ -265,7 +302,7 @@ def test_the_tokens_endpoint(api, json_response, doc_params):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.tokens(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -275,13 +312,11 @@ def test_the_tokens_endpoint(api, json_response, doc_params):
 def test_the_morphology_complete_endpoint(api, json_response, doc_params):
     """Test the morphology complete endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/complete",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -291,13 +326,11 @@ def test_the_morphology_complete_endpoint(api, json_response, doc_params):
 def test_the_morphology_lemmas_endpoint(api, json_response, doc_params):
     """Test the morphology lemmas endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/lemmas",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'lemmas')
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -307,13 +340,11 @@ def test_the_morphology_lemmas_endpoint(api, json_response, doc_params):
 def test_the_morphology_parts_of_speech_endpoint(api, json_response, doc_params):
     """Test the morphology parts-of-speech endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/parts-of-speech",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'parts-of-speech')
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -323,13 +354,11 @@ def test_the_morphology_parts_of_speech_endpoint(api, json_response, doc_params)
 def test_the_morphology_compound_components_endpoint(api, json_response, doc_params):
     """Test the morphology compound-components endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/compound-components",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'compound-components')
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -339,13 +368,11 @@ def test_the_morphology_compound_components_endpoint(api, json_response, doc_par
 def test_the_morphology_han_readings_endpoint(api, json_response, doc_params):
     """Test the morphology han-reading endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/han-readings",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'han-readings')
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -355,13 +382,11 @@ def test_the_morphology_han_readings_endpoint(api, json_response, doc_params):
 def test_the_entities_endpoint(api, json_response, doc_params):
     """Test the entities endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.entities(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -371,13 +396,11 @@ def test_the_entities_endpoint(api, json_response, doc_params):
 def test_the_categories_endpoint(api, json_response, doc_params):
     """Test the categories endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/categories",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.categories(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -387,13 +410,11 @@ def test_the_categories_endpoint(api, json_response, doc_params):
 def test_the_sentiment_endpoint(api, json_response, doc_params):
     """Test the sentiment endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentiment",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.sentiment(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -403,8 +424,6 @@ def test_the_sentiment_endpoint(api, json_response, doc_params):
 def test_the_multipart_operation(api, json_response, doc_params, tmpdir):
     """Test multipart"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentiment",
                            body=json_response, status=200, content_type="application/json")
 
@@ -412,7 +431,7 @@ def test_the_multipart_operation(api, json_response, doc_params, tmpdir):
     tmp_file.write(json_response)
     doc_params.load_document_file = tmp_file
     result = api.sentiment(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -420,8 +439,6 @@ def test_the_multipart_operation(api, json_response, doc_params, tmpdir):
 def test_incompatible_type(api, json_response):
     """Test the name translation endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentences",
                            body=json_response, status=200, content_type="application/json")
 
@@ -445,8 +462,6 @@ def test_incompatible_type(api, json_response):
 def test_the_name_translation_endpoint(api, json_response):
     """Test the name translation endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
@@ -456,7 +471,7 @@ def test_the_name_translation_endpoint(api, json_response):
     params["targetLanguage"] = "eng"
     params["targetScript"] = "Latn"
     result = api.name_translation(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -465,8 +480,6 @@ def test_the_name_translation_endpoint(api, json_response):
 def test_the_name_requests_with_text(api, json_response):
     """Test the name similarity with text"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
     with pytest.raises(RosetteException) as e_rosette:
@@ -496,8 +509,6 @@ def test_the_name_requests_with_text(api, json_response):
 def test_the_name_similarity_single_parameters(api, json_response):
     """Test the name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -509,7 +520,7 @@ def test_the_name_similarity_single_parameters(api, json_response):
     params["parameters"] = {"conflictScore": "0.9"}
 
     result = api.name_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -517,8 +528,6 @@ def test_the_name_similarity_single_parameters(api, json_response):
 def test_the_name_similarity_multiple_parameters(api, json_response):
     """Test the name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -530,7 +539,7 @@ def test_the_name_similarity_multiple_parameters(api, json_response):
     params["parameters"] = {"conflictScore": "0.9", "deletionScore": "0.5"}
 
     result = api.name_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -538,8 +547,6 @@ def test_the_name_similarity_multiple_parameters(api, json_response):
 def test_the_name_similarity_endpoint(api, json_response):
     """Test the name similarity endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -553,7 +560,7 @@ def test_the_name_similarity_endpoint(api, json_response):
     params["name2"] = {"text": matched_name_data2, "entityType": "PERSON"}
 
     result = api.name_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -564,8 +571,6 @@ def test_the_name_similarity_endpoint(api, json_response):
 def test_name_deduplication_parameters(api, json_response):
     """Test the Name Deduplication Parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-deduplication",
                            body=json_response, status=200, content_type="application/json")
 
@@ -580,7 +585,7 @@ def test_name_deduplication_parameters(api, json_response):
     params["names"] = ["John Smith", "Johnathon Smith", "Fred Jones"]
 
     result = api.name_deduplication(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
 
     httpretty.disable()
     httpretty.reset()
@@ -589,8 +594,6 @@ def test_name_deduplication_parameters(api, json_response):
 def test_the_name_deduplication_endpoint(api, json_response):
     """Test the name deduplication endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-deduplication",
                            body=json_response, status=200, content_type="application/json")
 
@@ -601,7 +604,7 @@ def test_the_name_deduplication_endpoint(api, json_response):
     params["threshold"] = threshold
 
     result = api.name_deduplication(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -611,8 +614,6 @@ def test_the_name_deduplication_endpoint(api, json_response):
 def test_the_relationships_endpoint(api, json_response):
     """Test the relationships endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/relationships",
                            body=json_response, status=200, content_type="application/json")
 
@@ -620,7 +621,7 @@ def test_the_relationships_endpoint(api, json_response):
     params["content"] = "some text data"
     api.set_option('accuracyMode', 'PRECISION')
     result = api.relationships(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -631,8 +632,6 @@ def test_for_404(api, json_response):
     """Test for 404 handling"""
     httpretty.enable()
     body = json.dumps({'message': 'not found'})
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.GET, "https://analytics.babelstreet.com/rest/v1/info",
                            body=body, status=404, content_type="application/json")
 
@@ -650,8 +649,6 @@ def test_for_404(api, json_response):
 def test_for_content_and_contentUri(api, json_response, doc_params):
     """Test for content and contentUri in DocumentParameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
@@ -670,8 +667,6 @@ def test_for_content_and_contentUri(api, json_response, doc_params):
 def test_for_no_content_or_contentUri(api, json_response, doc_params):
     """Test for missing content and contentUri in DocumentParameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
@@ -688,8 +683,6 @@ def test_for_no_content_or_contentUri(api, json_response, doc_params):
 def test_for_address_similarity_required_parameters(api, json_response):
     """Test address similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/address-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -716,7 +709,7 @@ def test_for_address_similarity_required_parameters(api, json_response):
     params["address2"] = {"text": "160 Pennsilvana Avenue, Washington, D.C., 20500"}
 
     result = api.address_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -724,8 +717,6 @@ def test_for_address_similarity_required_parameters(api, json_response):
 def test_for_address_similarity_optional_parameters(api, json_response):
     """Test address similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/address-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -742,7 +733,7 @@ def test_for_address_similarity_optional_parameters(api, json_response):
     params["parameters"] = {"houseNumberAddressFieldWeight": "0.9"}
 
     result = api.address_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -753,8 +744,6 @@ def test_for_address_similarity_optional_parameters(api, json_response):
 def test_for_name_similarity_required_parameters(api, json_response):
     """Test name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -781,7 +770,7 @@ def test_for_name_similarity_required_parameters(api, json_response):
     params["name2"] = {"text": matched_name_data2, "entityType": "PERSON"}
 
     result = api.name_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -791,8 +780,6 @@ def test_for_name_similarity_required_parameters(api, json_response):
 def test_for_name_translation_required_parameters(api, json_response):
     """Test name translation parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
@@ -817,7 +804,7 @@ def test_for_name_translation_required_parameters(api, json_response):
     params["targetLanguage"] = "eng"
 
     result = api.name_translation(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
 
     httpretty.disable()
     httpretty.reset()
@@ -830,7 +817,7 @@ def test_the_semantic_vectors_endpoint(api, json_response, doc_params):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.semantic_vectors(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -842,7 +829,7 @@ def test_the_syntax_dependencies_endpoint(api, json_response, doc_params):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.syntax_dependencies(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -852,15 +839,13 @@ def test_the_syntax_dependencies_endpoint(api, json_response, doc_params):
 def test_the_transliteration_endpoint(api, json_response):
     """Test the transliteration endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/transliteration",
                            body=json_response, status=200, content_type="application/json")
 
     params = DocumentParameters()
     params["content"] = "Some test content"
     result = api.transliteration(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -870,13 +855,11 @@ def test_the_transliteration_endpoint(api, json_response):
 def test_the_topics_endpoint(api, json_response, doc_params):
     """Test the topics endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/topics",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.topics(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -891,7 +874,7 @@ def test_the_similar_terms_endpoint(api, json_response, doc_params):
 
     api.set_option("resultLanguages", ["spa", "jpn", "deu"])
     result = api.similar_terms(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -905,14 +888,12 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
                            body=json_response, status=200, content_type="application/json")
 
     result = api.text_embedding(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
     # MATCHED_NAME calls NAME_SIMILARITY
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
@@ -926,14 +907,12 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
     name_similarity_params["name2"] = {"text": "迈克尔·杰克逊", "entityType": "PERSON"}
 
     result = api.matched_name(name_similarity_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
     # TRANSLATED_NAME calls NAME_TRANSLATION
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
@@ -944,7 +923,7 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
     name_translation_params["targetLanguage"] = "eng"
 
     result = api.translated_name(name_translation_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
 
     httpretty.disable()
     httpretty.reset()
@@ -955,13 +934,11 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
 def test_the_events_endpoint(api, json_response, doc_params):
     """Test the events endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
-                           body=json_response, status=200, content_type="application/json")
     httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/events",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.events(doc_params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -979,7 +956,7 @@ def test_the_record_similarity_endpoint(api, json_response):
     params["properties"] = {}
     params["records"] = {}
     result = api.record_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()
 
@@ -1002,6 +979,6 @@ def test_for_record_similarity_required_parameters(api, json_response):
     params["records"] = {}
 
     result = api.record_similarity(params)
-    assert result["name"] == "Rosette"
+    assert result["name"] == "Babel Street Analytics"
     httpretty.disable()
     httpretty.reset()

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -155,7 +155,7 @@ def test_user_agent(api):
 def test_ping(api, json_response):
     """Test ping"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.GET, "https://api.rosette.com/rest/v1/ping",
+    httpretty.register_uri(httpretty.GET, "https://analytics.babelstreet.com/rest/v1/ping",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.ping()
@@ -169,7 +169,7 @@ def test_ping(api, json_response):
 def test_info(api, json_response):
     """Test info"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.GET, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.GET, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.info()
@@ -184,7 +184,7 @@ def test_info(api, json_response):
 def test_for_409(api, json_409):
     """Test for 409 handling"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.GET, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.GET, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_409, status=409, content_type="application/json")
 
     with pytest.raises(RosetteException) as e_rosette:
@@ -200,7 +200,7 @@ def test_for_409(api, json_409):
 def test_the_max_pool_size(json_response, doc_params):
     """Test max pool size"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/language",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/language",
                            body=json_response, status=200, content_type="application/json",
                            adding_headers={
                                'x-rosetteapi-concurrency': 5
@@ -221,7 +221,7 @@ def test_the_max_pool_size(json_response, doc_params):
 def test_the_language_endpoint(api, json_response, doc_params, doc_map):
     """Test language endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/language",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/language",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.language(doc_params)
@@ -240,7 +240,7 @@ def test_the_language_endpoint(api, json_response, doc_params, doc_map):
 def test_the_sentences_endpoint(api, json_response, doc_params, doc_map):
     """Test the sentences endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/sentences",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentences",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.sentences(doc_params)
@@ -261,7 +261,7 @@ def test_the_sentences_endpoint(api, json_response, doc_params, doc_map):
 def test_the_tokens_endpoint(api, json_response, doc_params):
     """Test the tokens endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/tokens",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/tokens",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.tokens(doc_params)
@@ -275,9 +275,9 @@ def test_the_tokens_endpoint(api, json_response, doc_params):
 def test_the_morphology_complete_endpoint(api, json_response, doc_params):
     """Test the morphology complete endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/morphology/complete",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/complete",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params)
@@ -291,9 +291,9 @@ def test_the_morphology_complete_endpoint(api, json_response, doc_params):
 def test_the_morphology_lemmas_endpoint(api, json_response, doc_params):
     """Test the morphology lemmas endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/morphology/lemmas",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/lemmas",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'lemmas')
@@ -307,9 +307,9 @@ def test_the_morphology_lemmas_endpoint(api, json_response, doc_params):
 def test_the_morphology_parts_of_speech_endpoint(api, json_response, doc_params):
     """Test the morphology parts-of-speech endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/morphology/parts-of-speech",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/parts-of-speech",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'parts-of-speech')
@@ -323,9 +323,9 @@ def test_the_morphology_parts_of_speech_endpoint(api, json_response, doc_params)
 def test_the_morphology_compound_components_endpoint(api, json_response, doc_params):
     """Test the morphology compound-components endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/morphology/compound-components",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/compound-components",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'compound-components')
@@ -339,9 +339,9 @@ def test_the_morphology_compound_components_endpoint(api, json_response, doc_par
 def test_the_morphology_han_readings_endpoint(api, json_response, doc_params):
     """Test the morphology han-reading endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/morphology/han-readings",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/morphology/han-readings",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.morphology(doc_params, 'han-readings')
@@ -355,9 +355,9 @@ def test_the_morphology_han_readings_endpoint(api, json_response, doc_params):
 def test_the_entities_endpoint(api, json_response, doc_params):
     """Test the entities endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/entities",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.entities(doc_params)
@@ -371,9 +371,9 @@ def test_the_entities_endpoint(api, json_response, doc_params):
 def test_the_categories_endpoint(api, json_response, doc_params):
     """Test the categories endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/categories",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/categories",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.categories(doc_params)
@@ -387,9 +387,9 @@ def test_the_categories_endpoint(api, json_response, doc_params):
 def test_the_sentiment_endpoint(api, json_response, doc_params):
     """Test the sentiment endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/sentiment",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentiment",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.sentiment(doc_params)
@@ -403,9 +403,9 @@ def test_the_sentiment_endpoint(api, json_response, doc_params):
 def test_the_multipart_operation(api, json_response, doc_params, tmpdir):
     """Test multipart"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/sentiment",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentiment",
                            body=json_response, status=200, content_type="application/json")
 
     tmp_file = tmpdir.mkdir("sub").join("testfile.txt")
@@ -420,9 +420,9 @@ def test_the_multipart_operation(api, json_response, doc_params, tmpdir):
 def test_incompatible_type(api, json_response):
     """Test the name translation endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/sentences",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/sentences",
                            body=json_response, status=200, content_type="application/json")
 
     params = NameTranslationParameters()
@@ -445,9 +445,9 @@ def test_incompatible_type(api, json_response):
 def test_the_name_translation_endpoint(api, json_response):
     """Test the name translation endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-translation",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
     params = NameTranslationParameters()
@@ -465,9 +465,9 @@ def test_the_name_translation_endpoint(api, json_response):
 def test_the_name_requests_with_text(api, json_response):
     """Test the name similarity with text"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
     with pytest.raises(RosetteException) as e_rosette:
         result = api.name_similarity("should fail")
@@ -496,9 +496,9 @@ def test_the_name_requests_with_text(api, json_response):
 def test_the_name_similarity_single_parameters(api, json_response):
     """Test the name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     matched_name_data1 = "John Mike Smith"
@@ -517,9 +517,9 @@ def test_the_name_similarity_single_parameters(api, json_response):
 def test_the_name_similarity_multiple_parameters(api, json_response):
     """Test the name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     matched_name_data1 = "John Mike Smith"
@@ -538,9 +538,9 @@ def test_the_name_similarity_multiple_parameters(api, json_response):
 def test_the_name_similarity_endpoint(api, json_response):
     """Test the name similarity endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     matched_name_data1 = "Michael Jackson"
@@ -564,9 +564,9 @@ def test_the_name_similarity_endpoint(api, json_response):
 def test_name_deduplication_parameters(api, json_response):
     """Test the Name Deduplication Parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-deduplication",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-deduplication",
                            body=json_response, status=200, content_type="application/json")
 
     params = NameDeduplicationParameters()
@@ -589,9 +589,9 @@ def test_name_deduplication_parameters(api, json_response):
 def test_the_name_deduplication_endpoint(api, json_response):
     """Test the name deduplication endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-deduplication",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-deduplication",
                            body=json_response, status=200, content_type="application/json")
 
     dedup_list = ["John Smith", "Johnathon Smith", "Fred Jones"]
@@ -611,9 +611,9 @@ def test_the_name_deduplication_endpoint(api, json_response):
 def test_the_relationships_endpoint(api, json_response):
     """Test the relationships endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/relationships",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/relationships",
                            body=json_response, status=200, content_type="application/json")
 
     params = DocumentParameters()
@@ -631,9 +631,9 @@ def test_for_404(api, json_response):
     """Test for 404 handling"""
     httpretty.enable()
     body = json.dumps({'message': 'not found'})
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.GET, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.GET, "https://analytics.babelstreet.com/rest/v1/info",
                            body=body, status=404, content_type="application/json")
 
     with pytest.raises(RosetteException) as e_rosette:
@@ -650,9 +650,9 @@ def test_for_404(api, json_response):
 def test_for_content_and_contentUri(api, json_response, doc_params):
     """Test for content and contentUri in DocumentParameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/entities",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
     doc_params['contentUri'] = 'https://example.com'
@@ -670,9 +670,9 @@ def test_for_content_and_contentUri(api, json_response, doc_params):
 def test_for_no_content_or_contentUri(api, json_response, doc_params):
     """Test for missing content and contentUri in DocumentParameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/entities",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/entities",
                            body=json_response, status=200, content_type="application/json")
 
     doc_params['content'] = None
@@ -688,9 +688,9 @@ def test_for_no_content_or_contentUri(api, json_response, doc_params):
 def test_for_address_similarity_required_parameters(api, json_response):
     """Test address similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/address-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/address-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     params = AddressSimilarityParameters()
@@ -724,9 +724,9 @@ def test_for_address_similarity_required_parameters(api, json_response):
 def test_for_address_similarity_optional_parameters(api, json_response):
     """Test address similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/address-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/address-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     params = AddressSimilarityParameters()
@@ -753,9 +753,9 @@ def test_for_address_similarity_optional_parameters(api, json_response):
 def test_for_name_similarity_required_parameters(api, json_response):
     """Test name similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     matched_name_data1 = "Michael Jackson"
@@ -791,9 +791,9 @@ def test_for_name_similarity_required_parameters(api, json_response):
 def test_for_name_translation_required_parameters(api, json_response):
     """Test name translation parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-translation",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
     params = NameTranslationParameters()
@@ -826,7 +826,7 @@ def test_for_name_translation_required_parameters(api, json_response):
 def test_the_semantic_vectors_endpoint(api, json_response, doc_params):
     """Test semantic vectors endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/semantics/vector",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/semantics/vector",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.semantic_vectors(doc_params)
@@ -838,7 +838,7 @@ def test_the_semantic_vectors_endpoint(api, json_response, doc_params):
 def test_the_syntax_dependencies_endpoint(api, json_response, doc_params):
     """Test syntax dependencies endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/syntax/dependencies",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/syntax/dependencies",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.syntax_dependencies(doc_params)
@@ -852,9 +852,9 @@ def test_the_syntax_dependencies_endpoint(api, json_response, doc_params):
 def test_the_transliteration_endpoint(api, json_response):
     """Test the transliteration endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/transliteration",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/transliteration",
                            body=json_response, status=200, content_type="application/json")
 
     params = DocumentParameters()
@@ -870,9 +870,9 @@ def test_the_transliteration_endpoint(api, json_response):
 def test_the_topics_endpoint(api, json_response, doc_params):
     """Test the topics endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/topics",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/topics",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.topics(doc_params)
@@ -886,7 +886,7 @@ def test_the_topics_endpoint(api, json_response, doc_params):
 def test_the_similar_terms_endpoint(api, json_response, doc_params):
     """Test the similar terms endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/semantics/similar",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/semantics/similar",
                            body=json_response, status=200, content_type="application/json")
 
     api.set_option("resultLanguages", ["spa", "jpn", "deu"])
@@ -901,7 +901,7 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
 
     # TEXT_EMBEDDING calls SEMANTIC_VECTORS
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/semantics/vector",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/semantics/vector",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.text_embedding(doc_params)
@@ -911,9 +911,9 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
 
     # MATCHED_NAME calls NAME_SIMILARITY
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     name_similarity_params = NameSimilarityParameters()
@@ -932,9 +932,9 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
 
     # TRANSLATED_NAME calls NAME_TRANSLATION
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/name-translation",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/name-translation",
                            body=json_response, status=200, content_type="application/json")
 
     name_translation_params = NameTranslationParameters()
@@ -955,9 +955,9 @@ def test_the_deprecated_endpoints(api, json_response, doc_params):
 def test_the_events_endpoint(api, json_response, doc_params):
     """Test the events endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/info",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/info",
                            body=json_response, status=200, content_type="application/json")
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/events",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/events",
                            body=json_response, status=200, content_type="application/json")
 
     result = api.events(doc_params)
@@ -971,7 +971,7 @@ def test_the_events_endpoint(api, json_response, doc_params):
 def test_the_record_similarity_endpoint(api, json_response):
     """Test the record similarity endpoint"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/record-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/record-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     params = RecordSimilarityParameters()
@@ -988,7 +988,7 @@ def test_the_record_similarity_endpoint(api, json_response):
 def test_for_record_similarity_required_parameters(api, json_response):
     """Test record similarity parameters"""
     httpretty.enable()
-    httpretty.register_uri(httpretty.POST, "https://api.rosette.com/rest/v1/record-similarity",
+    httpretty.register_uri(httpretty.POST, "https://analytics.babelstreet.com/rest/v1/record-similarity",
                            body=json_response, status=200, content_type="application/json")
 
     params = RecordSimilarityParameters()


### PR DESCRIPTION
- Changed the default url to `analytics.babelstreet.com` and the default API key header to `X-BabelStreetAPI-Key`
- Updated the README to remove mentions of Rosette
- Replaced Rosette mentions in examples and document generation
- Updated package description