### PR TITLE
Nojira fix record similarity

### DIFF
--- a/rosette/api.py
+++ b/rosette/api.py
@@ -363,7 +363,7 @@ class RecordSimilarityParameters(_RequestParametersBase):
 
     def validate(self):
         """Internal. Do not use."""
-        for option in ["records"]:  # required
+        for option in ["records","fields"]:  # required
             if self[option] is None:
                 raise RosetteException(
                     "missingParameter",

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -978,6 +978,9 @@ def test_for_record_similarity_required_parameters(api, json_response):
 
     params["records"] = {}
 
+    with pytest.raises(RosetteException) as e_rosette:
+        api.record_similarity(params)
+
     assert e_rosette.value.status == 'missingParameter'
     assert e_rosette.value.message == 'Required Record Similarity parameter is missing: fields'
 

--- a/tests/test_rosette_api.py
+++ b/tests/test_rosette_api.py
@@ -978,6 +978,11 @@ def test_for_record_similarity_required_parameters(api, json_response):
 
     params["records"] = {}
 
+    assert e_rosette.value.status == 'missingParameter'
+    assert e_rosette.value.message == 'Required Record Similarity parameter is missing: fields'
+
+    params["fields"] = {}
+
     result = api.record_similarity(params)
     assert result["name"] == "Babel Street Analytics"
     httpretty.disable()


### PR DESCRIPTION
The reason behind the change is that record-similarity will not work with blank fields. This way we can spare the customer from calling the actual server and having network traffic (previously the error would come from RS, now it is stopped before the request is released)