### PR TITLE
NOJIRA: Remove warning filter

### DIFF
--- a/rosette/api.py
+++ b/rosette/api.py
@@ -24,7 +24,6 @@ import logging
 import sys
 import os
 import re
-import warnings
 import requests
 import platform
 
@@ -45,8 +44,6 @@ if _ISPY3:
     _GZIP_SIGNATURE = _GZIP_BYTEARRAY
 else:
     _GZIP_SIGNATURE = str(_GZIP_BYTEARRAY)
-
-warnings.simplefilter('always')
 
 
 class _ReturnObject(object):


### PR DESCRIPTION
* This overrode user's warning filters.
* This was (arguably) erroneously added to warn users of deprecations. However, DeprecationWarnings are intentionally ignored by default in Python.

Closes #119.